### PR TITLE
Scanner refactor

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -19,15 +19,13 @@ type Parser struct {
 }
 
 func NewParser(r io.Reader, file *token.File) *Parser {
-	s := NewScanner(r, file)
-	s.Scan() // TODO: Cleaner priming
-
-	return &Parser{
-		s:    s,
-		file: file, // TODO: Same file? Different file?
-		tok:  s.Token(),
-		lit:  s.Literal(),
+	p := &Parser{
+		s:    NewScanner(r, file),
+		file: file,
 	}
+	p.next()
+
+	return p
 }
 
 func (p *Parser) ParseFile() (*ast.File, error) {
@@ -56,12 +54,7 @@ func (p *Parser) error(pos token.Pos, msg string) {
 }
 
 func (p *Parser) next() {
-	if p.s.Scan() {
-		// TODO: p.pos
-		p.tok, p.lit = p.s.Token(), p.s.Literal()
-	} else {
-		p.tok = token.EOF
-	}
+	p.pos, p.tok, p.lit = p.s.Scan()
 }
 
 func (p *Parser) parseFile() *ast.File {

--- a/parser_test.go
+++ b/parser_test.go
@@ -35,6 +35,8 @@ var _ = Describe("Parser", func() {
 
 		_, err := p.ParseFile()
 
-		Expect(err).To(MatchError("expected 'IDENT'"))
+		Expect(err).To(MatchError(
+			ContainSubstring("expected 'IDENT'"),
+		))
 	})
 })

--- a/scanner.go
+++ b/scanner.go
@@ -119,11 +119,11 @@ func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
 }
 
 func (s *Scanner) next() {
-	s.done = !s.s.Scan()
 	s.offset = s.rdOffset
 	if bytes.ContainsRune(s.s.Bytes(), '\n') {
 		s.file.AddLine(s.offset)
 	}
+	s.done = !s.s.Scan()
 	s.rdOffset += len(s.s.Bytes())
 }
 

--- a/scanner.go
+++ b/scanner.go
@@ -21,11 +21,13 @@ type Scanner struct {
 }
 
 func NewScanner(r io.Reader, file *token.File) *Scanner {
+	scanner := bufio.NewScanner(r)
+	scanner.Split(ScanTokens)
+
 	s := &Scanner{
-		s:    bufio.NewScanner(r),
+		s:    scanner,
 		file: file,
 	}
-	s.s.Split(ScanTokens)
 	s.next()
 
 	return s
@@ -33,6 +35,10 @@ func NewScanner(r io.Reader, file *token.File) *Scanner {
 
 func (s Scanner) Err() error {
 	return s.s.Err()
+}
+
+func (s Scanner) Position(pos token.Pos) token.Position {
+	return token.PositionFor(s.file, pos)
 }
 
 func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {

--- a/scanner.go
+++ b/scanner.go
@@ -35,89 +35,80 @@ func (s Scanner) Err() error {
 	return s.s.Err()
 }
 
-func (s Scanner) Token() token.Token {
-	return s.tok
-}
-
-func (s Scanner) Literal() string {
-	return s.lit
-}
-
-func (s Scanner) Pos() token.Pos {
-	return s.file.Pos(s.offset)
-}
-
-func (s *Scanner) Scan() bool {
+func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
 	if s.done {
-		s.tok = token.EOF
-		return false
+		pos = s.file.Pos(s.offset)
+		tok = token.EOF
+		return
 	}
 
+	s.skipWhitespace()
+
+	// current token start
+	pos = s.file.Pos(s.offset)
 	var atNewline bool
 
-	s.skipWhitespace()
 	switch txt := s.s.Text(); {
 	case token.IsIdentifier(txt):
-		s.lit = txt
+		lit = txt
 		if len(txt) > 1 {
-			s.tok = token.Lookup(txt)
+			tok = token.Lookup(txt)
 		} else {
-			s.tok = token.IDENT
+			tok = token.IDENT
 		}
 	default:
+		s.next()
 		switch txt {
 		case "=":
-			s.tok = token.RECURSIVE_ASSIGN
+			tok = token.RECURSIVE_ASSIGN
 		case ":=":
-			s.tok = token.SIMPLE_ASSIGN
+			tok = token.SIMPLE_ASSIGN
 		case "::=":
-			s.tok = token.POSIX_ASSIGN
+			tok = token.POSIX_ASSIGN
 		case ":::=":
-			s.tok = token.IMMEDIATE_ASSIGN
+			tok = token.IMMEDIATE_ASSIGN
 		case "?=":
-			s.tok = token.IFNDEF_ASSIGN
+			tok = token.IFNDEF_ASSIGN
 		case "!=":
-			s.tok = token.SHELL_ASSIGN
+			tok = token.SHELL_ASSIGN
 		case ",":
-			s.tok = token.COMMA
+			tok = token.COMMA
 		case "\n":
 			atNewline = true
-			s.tok = token.NEWLINE
+			tok = token.NEWLINE
 		case "\t":
-			s.tok = token.TAB
+			tok = token.TAB
 		case "(":
-			s.tok = token.LPAREN
+			tok = token.LPAREN
 		case ")":
-			s.tok = token.RPAREN
+			tok = token.RPAREN
 		case "{":
-			s.tok = token.LBRACE
+			tok = token.LBRACE
 		case "}":
-			s.tok = token.RBRACE
+			tok = token.RBRACE
 		case "$":
-			s.tok = token.DOLLAR
+			tok = token.DOLLAR
 		case ":":
-			s.tok = token.COLON
+			tok = token.COLON
 		case ";":
-			s.tok = token.SEMI
+			tok = token.SEMI
 		case "|":
-			s.tok = token.PIPE
+			tok = token.PIPE
 		case "#":
 			// TODO
 			// s.lit = s.scanComment()
-			s.tok = token.COMMENT
+			tok = token.COMMENT
 		default:
-			s.tok = token.UNSUPPORTED
+			tok = token.UNSUPPORTED
 			s.lit = txt
 		}
 	}
 
-	s.next()
 	if atNewline && s.done {
-		s.tok = token.EOF
-		return false
-	} else {
-		return true
+		tok = token.EOF
 	}
+
+	return
 }
 
 func (s *Scanner) next() {

--- a/scanner.go
+++ b/scanner.go
@@ -51,6 +51,7 @@ func (s *Scanner) Scan() (pos token.Pos, tok token.Token, lit string) {
 	switch txt := s.s.Text(); {
 	case token.IsIdentifier(txt):
 		lit = txt
+		s.next()
 		if len(txt) > 1 {
 			tok = token.Lookup(txt)
 		} else {

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -71,9 +71,8 @@ var _ = Describe("Scanner", func() {
 		},
 	)
 
-	DescribeTable("Scan ident followed by token",
+	DescribeTable("Scan ident followed by whitespace",
 		Entry(nil, "ident $"),
-		Entry(nil, "ident:"),
 		Entry(nil, "ident :"),
 		Entry(nil, "ident ;"),
 		Entry(nil, "ident |"),
@@ -88,16 +87,19 @@ var _ = Describe("Scanner", func() {
 		Entry(nil, "ident {"),
 		Entry(nil, "ident }"),
 		Entry(nil, "ident ,"),
-		Entry(nil, "ident\n\t"),
 		func(input string) {
 			buf := bytes.NewBufferString(input)
 			s := make.NewScanner(buf, file)
 
 			pos, tok, lit := s.Scan()
-
 			Expect(tok).To(Equal(token.IDENT))
 			Expect(lit).To(Equal("ident"))
 			Expect(pos).To(Equal(token.Pos(1)))
+
+			pos, tok, lit = s.Scan()
+			// File base + Length of the identifier + whitespace
+			Expect(pos).To(Equal(token.Pos(7)))
+			Expect(tok).NotTo(Equal(token.IDENT))
 		},
 	)
 
@@ -123,9 +125,11 @@ var _ = Describe("Scanner", func() {
 			s := make.NewScanner(buf, file)
 
 			pos, tok, _ := s.Scan()
-
 			Expect(tok).To(Equal(expected))
 			Expect(pos).To(Equal(token.Pos(1)))
+
+			pos, tok, _ = s.Scan()
+			Expect(tok).To(Equal(token.EOF))
 		},
 	)
 

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -220,165 +220,104 @@ var _ = Describe("Scanner", func() {
 		},
 	)
 
-	// Describe("Pos", func() {
-	// 	DescribeTable("Starting token",
-	// 		Entry(nil, "$", 2),
-	// 		Entry(nil, ":", 2),
-	// 		Entry(nil, ";", 2),
-	// 		Entry(nil, "|", 2),
-	// 		Entry(nil, "=", 2),
-	// 		Entry(nil, ":=", 3),
-	// 		Entry(nil, "::=", 4),
-	// 		Entry(nil, ":::=", 5),
-	// 		Entry(nil, "?=", 3),
-	// 		Entry(nil, "!=", 3),
-	// 		Entry(nil, "(", 2),
-	// 		Entry(nil, ")", 2),
-	// 		Entry(nil, "{", 2),
-	// 		Entry(nil, "}", 2),
-	// 		Entry(nil, ",", 2),
-	// 		Entry(nil, "\t", 2),
-	// 		Entry(nil, "identifier", 11),
-	// 		Entry(nil, "$ foo", 2),
-	// 		Entry(nil, ": foo", 2),
-	// 		Entry(nil, "; foo", 2),
-	// 		Entry(nil, "| foo", 2),
-	// 		Entry(nil, "= foo", 2),
-	// 		Entry(nil, ":= foo", 3),
-	// 		Entry(nil, "::= foo", 4),
-	// 		Entry(nil, ":::= foo", 5),
-	// 		Entry(nil, "?= foo", 3),
-	// 		Entry(nil, "!= foo", 3),
-	// 		Entry(nil, "( foo", 2),
-	// 		Entry(nil, ") foo", 2),
-	// 		Entry(nil, "{ foo", 2),
-	// 		Entry(nil, "} foo", 2),
-	// 		Entry(nil, ", foo", 2),
-	// 		Entry(nil, "\t foo", 2),
-	// 		Entry(nil, "identifier foo", 11),
-	// 		func(input string, expected int) {
-	// 			buf := bytes.NewBufferString(input)
-	// 			s := make.NewScanner(buf, file)
+	DescribeTable("space separated tokens",
+		Entry(nil, "$ foo", 3),
+		Entry(nil, ": foo", 3),
+		Entry(nil, "; foo", 3),
+		Entry(nil, "| foo", 3),
+		Entry(nil, "= foo", 3),
+		Entry(nil, ":= foo", 4),
+		Entry(nil, "::= foo", 5),
+		Entry(nil, ":::= foo", 6),
+		Entry(nil, "?= foo", 4),
+		Entry(nil, "!= foo", 4),
+		Entry(nil, "( foo", 3),
+		Entry(nil, ") foo", 3),
+		Entry(nil, "{ foo", 3),
+		Entry(nil, "} foo", 3),
+		Entry(nil, ", foo", 3),
+		Entry(nil, "\t foo", 3),
+		Entry(nil, "identifier foo", 12),
+		Entry(nil, "$ foo bar", 3),
+		Entry(nil, ": foo bar", 3),
+		Entry(nil, "; foo bar", 3),
+		Entry(nil, "| foo bar", 3),
+		Entry(nil, "= foo bar", 3),
+		Entry(nil, ":= foo bar", 4),
+		Entry(nil, "::= foo bar", 5),
+		Entry(nil, ":::= foo bar", 6),
+		Entry(nil, "?= foo bar", 4),
+		Entry(nil, "!= foo bar", 4),
+		Entry(nil, "( foo bar", 3),
+		Entry(nil, ") foo bar", 3),
+		Entry(nil, "{ foo bar", 3),
+		Entry(nil, "} foo bar", 3),
+		Entry(nil, ", foo bar", 3),
+		Entry(nil, "\t foo bar", 3),
+		Entry(nil, "identifier foo bar", 12),
+		func(input string, expected int) {
+			buf := bytes.NewBufferString(input)
+			s := make.NewScanner(buf, file)
 
-	// 			pos, tok, lit := s.Scan()
+			_, _, _ = s.Scan()
+			pos, tok, lit := s.Scan()
+			Expect(tok).To(Equal(token.IDENT))
+			Expect(pos).To(Equal(token.Pos(expected)))
+			Expect(lit).To(Equal("foo"))
+			Expect(s.Position(pos)).To(Equal(token.Position{
+				Filename: file.Name(),
+				Offset:   expected - file.Base(),
+				Line:     1,
+				Column:   expected,
+			}))
+		},
+	)
 
-	// 			Expect(pos).To(Equal(token.Pos(expected)))
-	// 		},
-	// 	)
+	DescribeTable("newline separated tokens",
+		Entry(nil, "$\nfoo", 2),
+		Entry(nil, ":\nfoo", 2),
+		Entry(nil, ";\nfoo", 2),
+		Entry(nil, "|\nfoo", 2),
+		Entry(nil, "=\nfoo", 2),
+		Entry(nil, ":=\nfoo", 3),
+		Entry(nil, "::=\nfoo", 4),
+		Entry(nil, ":::=\nfoo", 5),
+		Entry(nil, "?=\nfoo", 3),
+		Entry(nil, "!=\nfoo", 3),
+		Entry(nil, "(\nfoo", 2),
+		Entry(nil, ")\nfoo", 2),
+		Entry(nil, "{\nfoo", 2),
+		Entry(nil, "}\nfoo", 2),
+		Entry(nil, ",\nfoo", 2),
+		Entry(nil, "\t\nfoo", 2),
+		Entry(nil, "identifier\nfoo", 11),
+		func(input string, nlPos int) {
+			buf := bytes.NewBufferString(input)
+			s := make.NewScanner(buf, file)
 
-	// 	DescribeTable("Second token",
-	// 		Entry(nil, "$ foo", 6),
-	// 		Entry(nil, ": foo", 6),
-	// 		Entry(nil, "; foo", 6),
-	// 		Entry(nil, "| foo", 6),
-	// 		Entry(nil, "= foo", 6),
-	// 		Entry(nil, ":= foo", 7),
-	// 		Entry(nil, "::= foo", 8),
-	// 		Entry(nil, ":::= foo", 9),
-	// 		Entry(nil, "?= foo", 7),
-	// 		Entry(nil, "!= foo", 7),
-	// 		Entry(nil, "( foo", 6),
-	// 		Entry(nil, ") foo", 6),
-	// 		Entry(nil, "{ foo", 6),
-	// 		Entry(nil, "} foo", 6),
-	// 		Entry(nil, ", foo", 6),
-	// 		Entry(nil, "\t foo", 6),
-	// 		Entry(nil, "identifier foo", 15),
-	// 		Entry(nil, "$ foo bar", 6),
-	// 		Entry(nil, ": foo bar", 6),
-	// 		Entry(nil, "; foo bar", 6),
-	// 		Entry(nil, "| foo bar", 6),
-	// 		Entry(nil, "= foo bar", 6),
-	// 		Entry(nil, ":= foo bar", 7),
-	// 		Entry(nil, "::= foo bar", 8),
-	// 		Entry(nil, ":::= foo bar", 9),
-	// 		Entry(nil, "?= foo bar", 7),
-	// 		Entry(nil, "!= foo bar", 7),
-	// 		Entry(nil, "( foo bar", 6),
-	// 		Entry(nil, ") foo bar", 6),
-	// 		Entry(nil, "{ foo bar", 6),
-	// 		Entry(nil, "} foo bar", 6),
-	// 		Entry(nil, ", foo bar", 6),
-	// 		Entry(nil, "\t foo bar", 6),
-	// 		Entry(nil, "identifier foo bar", 15),
-	// 		func(input string, expected int) {
-	// 			buf := bytes.NewBufferString(input)
-	// 			s := make.NewScanner(buf, file)
+			_, _, _ = s.Scan()
+			pos, tok, _ := s.Scan()
+			Expect(tok).To(Equal(token.NEWLINE))
+			Expect(pos).To(Equal(token.Pos(nlPos)))
+			Expect(s.Position(pos)).To(Equal(token.Position{
+				Filename: file.Name(),
+				Offset:   nlPos - file.Base(),
+				Line:     1,
+				Column:   nlPos,
+			}))
 
-	// 			Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
-	// 			Expect(s.Scan()).To(BeTrueBecause("scanned another token"))
-	// 			Expect(s.Pos()).To(Equal(token.Pos(expected)))
-	// 		},
-	// 	)
-
-	// 	DescribeTable("Scan newline",
-	// 		Entry(nil, "$\nfoo", 3),
-	// 		Entry(nil, ":\nfoo", 3),
-	// 		Entry(nil, ";\nfoo", 3),
-	// 		Entry(nil, "|\nfoo", 3),
-	// 		Entry(nil, "=\nfoo", 3),
-	// 		Entry(nil, ":=\nfoo", 4),
-	// 		Entry(nil, "::=\nfoo", 5),
-	// 		Entry(nil, ":::=\nfoo", 6),
-	// 		Entry(nil, "?=\nfoo", 4),
-	// 		Entry(nil, "!=\nfoo", 4),
-	// 		Entry(nil, "(\nfoo", 3),
-	// 		Entry(nil, ")\nfoo", 3),
-	// 		Entry(nil, "{\nfoo", 3),
-	// 		Entry(nil, "}\nfoo", 3),
-	// 		Entry(nil, ",\nfoo", 3),
-	// 		Entry(nil, "\t\nfoo", 3),
-	// 		Entry(nil, "identifier\nfoo", 12),
-	// 		func(input string, expected int) {
-	// 			buf := bytes.NewBufferString(input)
-	// 			s := make.NewScanner(buf, file)
-
-	// 			Expect(s.Scan()).To(BeTrueBecause("scanned first token"))
-	// 			Expect(s.Scan()).To(BeTrueBecause("scanned newline token"))
-	// 			Expect(s.Pos()).To(Equal(token.Pos(expected)))
-	// 			Expect(file.PositionFor(s.Pos(), false)).To(Equal(token.Position{
-	// 				Filename: file.Name(),
-	// 				Offset:   expected - file.Base(),
-	// 				Line:     2,
-	// 				Column:   2,
-	// 			}))
-	// 		},
-	// 	)
-
-	// 	DescribeTable("Scan final newline",
-	// 		Entry(nil, "$\n", 3),
-	// 		Entry(nil, ":\n", 3),
-	// 		Entry(nil, ";\n", 3),
-	// 		Entry(nil, "|\n", 3),
-	// 		Entry(nil, "=\n", 3),
-	// 		Entry(nil, ":=\n", 4),
-	// 		Entry(nil, "::=\n", 5),
-	// 		Entry(nil, ":::=\n", 6),
-	// 		Entry(nil, "?=\n", 4),
-	// 		Entry(nil, "!=\n", 4),
-	// 		Entry(nil, "(\n", 3),
-	// 		Entry(nil, ")\n", 3),
-	// 		Entry(nil, "{\n", 3),
-	// 		Entry(nil, "}\n", 3),
-	// 		Entry(nil, ",\n", 3),
-	// 		Entry(nil, "\t\n", 3),
-	// 		Entry(nil, "identifier\n", 12),
-	// 		func(input string, expected int) {
-	// 			buf := bytes.NewBufferString(input)
-	// 			s := make.NewScanner(buf, file)
-
-	// 			Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
-	// 			Expect(s.Scan()).To(BeFalseBecause("scanned final newline"))
-	// 			Expect(s.Pos()).To(Equal(token.Pos(expected)))
-	// 			Expect(file.PositionFor(s.Pos(), false)).To(Equal(token.Position{
-	// 				Filename: file.Name(),
-	// 				Offset:   expected - file.Base(),
-	// 				Line:     2,
-	// 				Column:   2,
-	// 			}))
-	// 		},
-	// 	)
-	// })
+			pos, tok, lit := s.Scan()
+			Expect(tok).To(Equal(token.IDENT))
+			Expect(pos).To(Equal(token.Pos(nlPos + 1)))
+			Expect(lit).To(Equal("foo"))
+			Expect(s.Position(pos)).To(Equal(token.Position{
+				Filename: file.Name(),
+				Offset:   nlPos,
+				Line:     2,
+				Column:   1,
+			}))
+		},
+	)
 
 	It("should return IO errors", func() {
 		r := testing.ErrReader("io error")

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -37,12 +37,12 @@ var _ = Describe("Scanner", func() {
 
 			pos, tok, lit := s.Scan()
 			Expect(tok).To(Equal(token.IDENT))
-			Expect(lit).To(Equal(strings.TrimSpace(input)))
+			Expect(lit).To(Equal(input))
 			Expect(pos).To(Equal(token.Pos(1)))
 
 			pos, tok, lit = s.Scan()
 			Expect(tok).To(Equal(token.EOF))
-			Expect(pos).To(Equal(token.Pos(len(input))))
+			Expect(pos).To(Equal(token.Pos(len(input) + 1)))
 		},
 	)
 
@@ -315,7 +315,7 @@ var _ = Describe("Scanner", func() {
 		r := testing.ErrReader("io error")
 		s := make.NewScanner(r, file)
 
-		Expect(s.Scan()).To(BeFalse())
+		_, _, _ = s.Scan()
 		Expect(s.Err()).To(MatchError("io error"))
 	})
 })

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -82,6 +82,12 @@ var _ = Describe("Scanner", func() {
 			Expect(tok).To(Equal(token.IDENT))
 			Expect(lit).To(Equal(strings.TrimSpace(input)))
 			Expect(pos).To(Equal(token.Pos(1)))
+			Expect(s.Position(pos)).To(Equal(token.Position{
+				Filename: file.Name(),
+				Offset:   0,
+				Line:     1,
+				Column:   1,
+			}))
 
 			pos, tok, lit = s.Scan()
 			Expect(tok).To(Equal(token.EOF))
@@ -89,8 +95,8 @@ var _ = Describe("Scanner", func() {
 			Expect(s.Position(pos)).To(Equal(token.Position{
 				Filename: file.Name(),
 				Offset:   len(input) - 1,
-				Line:     2,
-				Column:   1,
+				Line:     1,
+				Column:   len(input),
 			}))
 		},
 	)
@@ -171,14 +177,48 @@ var _ = Describe("Scanner", func() {
 		},
 	)
 
-	It("should scan newline followed by token", func() {
-		buf := bytes.NewBufferString("\nident")
-		s := make.NewScanner(buf, file)
+	DescribeTable("should scan newline followed by token",
+		Entry(nil, "\nident"),
+		Entry(nil, "\n,"),
+		Entry(nil, "\n$"),
+		Entry(nil, "\n;"),
+		Entry(nil, "\n:"),
+		Entry(nil, "\n:="),
+		Entry(nil, "\n::="),
+		Entry(nil, "\n:::="),
+		Entry(nil, "\n="),
+		Entry(nil, "\n?="),
+		Entry(nil, "\n!="),
+		Entry(nil, "\n|"),
+		Entry(nil, "\n\t"),
+		Entry(nil, "\n{"),
+		Entry(nil, "\n}"),
+		Entry(nil, "\n("),
+		Entry(nil, "\n)"),
+		func(input string) {
+			buf := bytes.NewBufferString(input)
+			s := make.NewScanner(buf, file)
 
-		pos, tok, _ := s.Scan()
-		Expect(tok).To(Equal(token.NEWLINE))
-		Expect(pos).To(Equal(token.Pos(1)))
-	})
+			pos, tok, _ := s.Scan()
+			Expect(tok).To(Equal(token.NEWLINE))
+			Expect(pos).To(Equal(token.Pos(1)))
+			Expect(s.Position(pos)).To(Equal(token.Position{
+				Filename: file.Name(),
+				Offset:   0,
+				Line:     1,
+				Column:   1,
+			}))
+
+			pos, tok, _ = s.Scan()
+			Expect(pos).To(Equal(token.Pos(2)))
+			Expect(s.Position(pos)).To(Equal(token.Position{
+				Filename: file.Name(),
+				Offset:   1,
+				Line:     2,
+				Column:   1,
+			}))
+		},
+	)
 
 	// Describe("Pos", func() {
 	// 	DescribeTable("Starting token",

--- a/scanner_test.go
+++ b/scanner_test.go
@@ -35,11 +35,14 @@ var _ = Describe("Scanner", func() {
 			buf := bytes.NewBufferString(input)
 			s := make.NewScanner(buf, file)
 
-			Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
-			Expect(s.Token()).To(Equal(token.IDENT))
-			Expect(s.Literal()).To(Equal(strings.TrimSpace(input)))
-			Expect(s.Scan()).To(BeFalseBecause("at EOF"))
-			Expect(s.Token()).To(Equal(token.EOF))
+			pos, tok, lit := s.Scan()
+			Expect(tok).To(Equal(token.IDENT))
+			Expect(lit).To(Equal(strings.TrimSpace(input)))
+			Expect(pos).To(Equal(token.Pos(1)))
+
+			pos, tok, lit = s.Scan()
+			Expect(tok).To(Equal(token.EOF))
+			Expect(pos).To(Equal(token.Pos(len(input))))
 		},
 	)
 
@@ -57,11 +60,14 @@ var _ = Describe("Scanner", func() {
 			buf := bytes.NewBufferString(input)
 			s := make.NewScanner(buf, file)
 
-			Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
-			Expect(s.Token()).To(Equal(token.IDENT))
-			Expect(s.Literal()).To(Equal(strings.TrimSpace(input)))
-			Expect(s.Scan()).To(BeFalseBecause("at EOF"))
-			Expect(s.Token()).To(Equal(token.EOF))
+			pos, tok, lit := s.Scan()
+			Expect(tok).To(Equal(token.IDENT))
+			Expect(lit).To(Equal(strings.TrimSpace(input)))
+			Expect(pos).To(Equal(token.Pos(1)))
+
+			pos, tok, lit = s.Scan()
+			Expect(tok).To(Equal(token.EOF))
+			Expect(pos).To(Equal(token.Pos(len(input))))
 		},
 	)
 
@@ -87,11 +93,11 @@ var _ = Describe("Scanner", func() {
 			buf := bytes.NewBufferString(input)
 			s := make.NewScanner(buf, file)
 
-			ok := s.Scan()
+			pos, tok, lit := s.Scan()
 
-			Expect(s.Token()).To(Equal(token.IDENT))
-			Expect(s.Literal()).To(Equal("ident"))
-			Expect(ok).To(BeTrueBecause("scanned a token"))
+			Expect(tok).To(Equal(token.IDENT))
+			Expect(lit).To(Equal("ident"))
+			Expect(pos).To(Equal(token.Pos(1)))
 		},
 	)
 
@@ -116,10 +122,10 @@ var _ = Describe("Scanner", func() {
 			buf := bytes.NewBufferString(input)
 			s := make.NewScanner(buf, file)
 
-			ok := s.Scan()
+			pos, tok, _ := s.Scan()
 
-			Expect(s.Token()).To(Equal(expected))
-			Expect(ok).To(BeTrueBecause("scanned a token"))
+			Expect(tok).To(Equal(expected))
+			Expect(pos).To(Equal(token.Pos(1)))
 		},
 	)
 
@@ -129,10 +135,10 @@ var _ = Describe("Scanner", func() {
 			buf := bytes.NewBufferString(input)
 			s := make.NewScanner(buf, file)
 
-			ok := s.Scan()
+			pos, tok, _ := s.Scan()
 
-			Expect(s.Token()).To(Equal(expected))
-			Expect(ok).To(BeTrueBecause("scanned a token"))
+			Expect(tok).To(Equal(expected))
+			Expect(pos).To(Equal(token.Pos(1)))
 		},
 	)
 
@@ -140,168 +146,170 @@ var _ = Describe("Scanner", func() {
 		buf := bytes.NewBufferString("\n ident")
 		s := make.NewScanner(buf, file)
 
-		Expect(s.Scan()).To(BeTrue())
-		Expect(s.Token()).To(Equal(token.NEWLINE))
+		pos, tok, _ := s.Scan()
+		Expect(tok).To(Equal(token.NEWLINE))
+		Expect(pos).To(Equal(token.Pos(1)))
 	})
 
-	Describe("Pos", func() {
-		DescribeTable("Starting token",
-			Entry(nil, "$", 2),
-			Entry(nil, ":", 2),
-			Entry(nil, ";", 2),
-			Entry(nil, "|", 2),
-			Entry(nil, "=", 2),
-			Entry(nil, ":=", 3),
-			Entry(nil, "::=", 4),
-			Entry(nil, ":::=", 5),
-			Entry(nil, "?=", 3),
-			Entry(nil, "!=", 3),
-			Entry(nil, "(", 2),
-			Entry(nil, ")", 2),
-			Entry(nil, "{", 2),
-			Entry(nil, "}", 2),
-			Entry(nil, ",", 2),
-			Entry(nil, "\t", 2),
-			Entry(nil, "identifier", 11),
-			Entry(nil, "$ foo", 2),
-			Entry(nil, ": foo", 2),
-			Entry(nil, "; foo", 2),
-			Entry(nil, "| foo", 2),
-			Entry(nil, "= foo", 2),
-			Entry(nil, ":= foo", 3),
-			Entry(nil, "::= foo", 4),
-			Entry(nil, ":::= foo", 5),
-			Entry(nil, "?= foo", 3),
-			Entry(nil, "!= foo", 3),
-			Entry(nil, "( foo", 2),
-			Entry(nil, ") foo", 2),
-			Entry(nil, "{ foo", 2),
-			Entry(nil, "} foo", 2),
-			Entry(nil, ", foo", 2),
-			Entry(nil, "\t foo", 2),
-			Entry(nil, "identifier foo", 11),
-			func(input string, expected int) {
-				buf := bytes.NewBufferString(input)
-				s := make.NewScanner(buf, file)
+	// Describe("Pos", func() {
+	// 	DescribeTable("Starting token",
+	// 		Entry(nil, "$", 2),
+	// 		Entry(nil, ":", 2),
+	// 		Entry(nil, ";", 2),
+	// 		Entry(nil, "|", 2),
+	// 		Entry(nil, "=", 2),
+	// 		Entry(nil, ":=", 3),
+	// 		Entry(nil, "::=", 4),
+	// 		Entry(nil, ":::=", 5),
+	// 		Entry(nil, "?=", 3),
+	// 		Entry(nil, "!=", 3),
+	// 		Entry(nil, "(", 2),
+	// 		Entry(nil, ")", 2),
+	// 		Entry(nil, "{", 2),
+	// 		Entry(nil, "}", 2),
+	// 		Entry(nil, ",", 2),
+	// 		Entry(nil, "\t", 2),
+	// 		Entry(nil, "identifier", 11),
+	// 		Entry(nil, "$ foo", 2),
+	// 		Entry(nil, ": foo", 2),
+	// 		Entry(nil, "; foo", 2),
+	// 		Entry(nil, "| foo", 2),
+	// 		Entry(nil, "= foo", 2),
+	// 		Entry(nil, ":= foo", 3),
+	// 		Entry(nil, "::= foo", 4),
+	// 		Entry(nil, ":::= foo", 5),
+	// 		Entry(nil, "?= foo", 3),
+	// 		Entry(nil, "!= foo", 3),
+	// 		Entry(nil, "( foo", 2),
+	// 		Entry(nil, ") foo", 2),
+	// 		Entry(nil, "{ foo", 2),
+	// 		Entry(nil, "} foo", 2),
+	// 		Entry(nil, ", foo", 2),
+	// 		Entry(nil, "\t foo", 2),
+	// 		Entry(nil, "identifier foo", 11),
+	// 		func(input string, expected int) {
+	// 			buf := bytes.NewBufferString(input)
+	// 			s := make.NewScanner(buf, file)
 
-				Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
-				Expect(s.Pos()).To(Equal(token.Pos(expected)))
-			},
-		)
+	// 			pos, tok, lit := s.Scan()
 
-		DescribeTable("Second token",
-			Entry(nil, "$ foo", 6),
-			Entry(nil, ": foo", 6),
-			Entry(nil, "; foo", 6),
-			Entry(nil, "| foo", 6),
-			Entry(nil, "= foo", 6),
-			Entry(nil, ":= foo", 7),
-			Entry(nil, "::= foo", 8),
-			Entry(nil, ":::= foo", 9),
-			Entry(nil, "?= foo", 7),
-			Entry(nil, "!= foo", 7),
-			Entry(nil, "( foo", 6),
-			Entry(nil, ") foo", 6),
-			Entry(nil, "{ foo", 6),
-			Entry(nil, "} foo", 6),
-			Entry(nil, ", foo", 6),
-			Entry(nil, "\t foo", 6),
-			Entry(nil, "identifier foo", 15),
-			Entry(nil, "$ foo bar", 6),
-			Entry(nil, ": foo bar", 6),
-			Entry(nil, "; foo bar", 6),
-			Entry(nil, "| foo bar", 6),
-			Entry(nil, "= foo bar", 6),
-			Entry(nil, ":= foo bar", 7),
-			Entry(nil, "::= foo bar", 8),
-			Entry(nil, ":::= foo bar", 9),
-			Entry(nil, "?= foo bar", 7),
-			Entry(nil, "!= foo bar", 7),
-			Entry(nil, "( foo bar", 6),
-			Entry(nil, ") foo bar", 6),
-			Entry(nil, "{ foo bar", 6),
-			Entry(nil, "} foo bar", 6),
-			Entry(nil, ", foo bar", 6),
-			Entry(nil, "\t foo bar", 6),
-			Entry(nil, "identifier foo bar", 15),
-			func(input string, expected int) {
-				buf := bytes.NewBufferString(input)
-				s := make.NewScanner(buf, file)
+	// 			Expect(pos).To(Equal(token.Pos(expected)))
+	// 		},
+	// 	)
 
-				Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
-				Expect(s.Scan()).To(BeTrueBecause("scanned another token"))
-				Expect(s.Pos()).To(Equal(token.Pos(expected)))
-			},
-		)
+	// 	DescribeTable("Second token",
+	// 		Entry(nil, "$ foo", 6),
+	// 		Entry(nil, ": foo", 6),
+	// 		Entry(nil, "; foo", 6),
+	// 		Entry(nil, "| foo", 6),
+	// 		Entry(nil, "= foo", 6),
+	// 		Entry(nil, ":= foo", 7),
+	// 		Entry(nil, "::= foo", 8),
+	// 		Entry(nil, ":::= foo", 9),
+	// 		Entry(nil, "?= foo", 7),
+	// 		Entry(nil, "!= foo", 7),
+	// 		Entry(nil, "( foo", 6),
+	// 		Entry(nil, ") foo", 6),
+	// 		Entry(nil, "{ foo", 6),
+	// 		Entry(nil, "} foo", 6),
+	// 		Entry(nil, ", foo", 6),
+	// 		Entry(nil, "\t foo", 6),
+	// 		Entry(nil, "identifier foo", 15),
+	// 		Entry(nil, "$ foo bar", 6),
+	// 		Entry(nil, ": foo bar", 6),
+	// 		Entry(nil, "; foo bar", 6),
+	// 		Entry(nil, "| foo bar", 6),
+	// 		Entry(nil, "= foo bar", 6),
+	// 		Entry(nil, ":= foo bar", 7),
+	// 		Entry(nil, "::= foo bar", 8),
+	// 		Entry(nil, ":::= foo bar", 9),
+	// 		Entry(nil, "?= foo bar", 7),
+	// 		Entry(nil, "!= foo bar", 7),
+	// 		Entry(nil, "( foo bar", 6),
+	// 		Entry(nil, ") foo bar", 6),
+	// 		Entry(nil, "{ foo bar", 6),
+	// 		Entry(nil, "} foo bar", 6),
+	// 		Entry(nil, ", foo bar", 6),
+	// 		Entry(nil, "\t foo bar", 6),
+	// 		Entry(nil, "identifier foo bar", 15),
+	// 		func(input string, expected int) {
+	// 			buf := bytes.NewBufferString(input)
+	// 			s := make.NewScanner(buf, file)
 
-		DescribeTable("Scan newline",
-			Entry(nil, "$\nfoo", 3),
-			Entry(nil, ":\nfoo", 3),
-			Entry(nil, ";\nfoo", 3),
-			Entry(nil, "|\nfoo", 3),
-			Entry(nil, "=\nfoo", 3),
-			Entry(nil, ":=\nfoo", 4),
-			Entry(nil, "::=\nfoo", 5),
-			Entry(nil, ":::=\nfoo", 6),
-			Entry(nil, "?=\nfoo", 4),
-			Entry(nil, "!=\nfoo", 4),
-			Entry(nil, "(\nfoo", 3),
-			Entry(nil, ")\nfoo", 3),
-			Entry(nil, "{\nfoo", 3),
-			Entry(nil, "}\nfoo", 3),
-			Entry(nil, ",\nfoo", 3),
-			Entry(nil, "\t\nfoo", 3),
-			Entry(nil, "identifier\nfoo", 12),
-			func(input string, expected int) {
-				buf := bytes.NewBufferString(input)
-				s := make.NewScanner(buf, file)
+	// 			Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
+	// 			Expect(s.Scan()).To(BeTrueBecause("scanned another token"))
+	// 			Expect(s.Pos()).To(Equal(token.Pos(expected)))
+	// 		},
+	// 	)
 
-				Expect(s.Scan()).To(BeTrueBecause("scanned first token"))
-				Expect(s.Scan()).To(BeTrueBecause("scanned newline token"))
-				Expect(s.Pos()).To(Equal(token.Pos(expected)))
-				Expect(file.PositionFor(s.Pos(), false)).To(Equal(token.Position{
-					Filename: file.Name(),
-					Offset:   expected - file.Base(),
-					Line:     2,
-					Column:   2,
-				}))
-			},
-		)
+	// 	DescribeTable("Scan newline",
+	// 		Entry(nil, "$\nfoo", 3),
+	// 		Entry(nil, ":\nfoo", 3),
+	// 		Entry(nil, ";\nfoo", 3),
+	// 		Entry(nil, "|\nfoo", 3),
+	// 		Entry(nil, "=\nfoo", 3),
+	// 		Entry(nil, ":=\nfoo", 4),
+	// 		Entry(nil, "::=\nfoo", 5),
+	// 		Entry(nil, ":::=\nfoo", 6),
+	// 		Entry(nil, "?=\nfoo", 4),
+	// 		Entry(nil, "!=\nfoo", 4),
+	// 		Entry(nil, "(\nfoo", 3),
+	// 		Entry(nil, ")\nfoo", 3),
+	// 		Entry(nil, "{\nfoo", 3),
+	// 		Entry(nil, "}\nfoo", 3),
+	// 		Entry(nil, ",\nfoo", 3),
+	// 		Entry(nil, "\t\nfoo", 3),
+	// 		Entry(nil, "identifier\nfoo", 12),
+	// 		func(input string, expected int) {
+	// 			buf := bytes.NewBufferString(input)
+	// 			s := make.NewScanner(buf, file)
 
-		DescribeTable("Scan final newline",
-			Entry(nil, "$\n", 3),
-			Entry(nil, ":\n", 3),
-			Entry(nil, ";\n", 3),
-			Entry(nil, "|\n", 3),
-			Entry(nil, "=\n", 3),
-			Entry(nil, ":=\n", 4),
-			Entry(nil, "::=\n", 5),
-			Entry(nil, ":::=\n", 6),
-			Entry(nil, "?=\n", 4),
-			Entry(nil, "!=\n", 4),
-			Entry(nil, "(\n", 3),
-			Entry(nil, ")\n", 3),
-			Entry(nil, "{\n", 3),
-			Entry(nil, "}\n", 3),
-			Entry(nil, ",\n", 3),
-			Entry(nil, "\t\n", 3),
-			Entry(nil, "identifier\n", 12),
-			func(input string, expected int) {
-				buf := bytes.NewBufferString(input)
-				s := make.NewScanner(buf, file)
+	// 			Expect(s.Scan()).To(BeTrueBecause("scanned first token"))
+	// 			Expect(s.Scan()).To(BeTrueBecause("scanned newline token"))
+	// 			Expect(s.Pos()).To(Equal(token.Pos(expected)))
+	// 			Expect(file.PositionFor(s.Pos(), false)).To(Equal(token.Position{
+	// 				Filename: file.Name(),
+	// 				Offset:   expected - file.Base(),
+	// 				Line:     2,
+	// 				Column:   2,
+	// 			}))
+	// 		},
+	// 	)
 
-				Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
-				Expect(s.Scan()).To(BeFalseBecause("scanned final newline"))
-				Expect(s.Pos()).To(Equal(token.Pos(expected)))
-				Expect(file.PositionFor(s.Pos(), false)).To(Equal(token.Position{
-					Filename: file.Name(),
-					Offset:   expected - file.Base(),
-					Line:     2,
-					Column:   2,
-				}))
-			},
-		)
-	})
+	// 	DescribeTable("Scan final newline",
+	// 		Entry(nil, "$\n", 3),
+	// 		Entry(nil, ":\n", 3),
+	// 		Entry(nil, ";\n", 3),
+	// 		Entry(nil, "|\n", 3),
+	// 		Entry(nil, "=\n", 3),
+	// 		Entry(nil, ":=\n", 4),
+	// 		Entry(nil, "::=\n", 5),
+	// 		Entry(nil, ":::=\n", 6),
+	// 		Entry(nil, "?=\n", 4),
+	// 		Entry(nil, "!=\n", 4),
+	// 		Entry(nil, "(\n", 3),
+	// 		Entry(nil, ")\n", 3),
+	// 		Entry(nil, "{\n", 3),
+	// 		Entry(nil, "}\n", 3),
+	// 		Entry(nil, ",\n", 3),
+	// 		Entry(nil, "\t\n", 3),
+	// 		Entry(nil, "identifier\n", 12),
+	// 		func(input string, expected int) {
+	// 			buf := bytes.NewBufferString(input)
+	// 			s := make.NewScanner(buf, file)
+
+	// 			Expect(s.Scan()).To(BeTrueBecause("scanned a token"))
+	// 			Expect(s.Scan()).To(BeFalseBecause("scanned final newline"))
+	// 			Expect(s.Pos()).To(Equal(token.Pos(expected)))
+	// 			Expect(file.PositionFor(s.Pos(), false)).To(Equal(token.Position{
+	// 				Filename: file.Name(),
+	// 				Offset:   expected - file.Base(),
+	// 				Line:     2,
+	// 				Column:   2,
+	// 			}))
+	// 		},
+	// 	)
+	// })
 
 	It("should return IO errors", func() {
 		r := testing.ErrReader("io error")

--- a/token/position.go
+++ b/token/position.go
@@ -10,3 +10,11 @@ type (
 )
 
 const NoPos = token.NoPos
+
+// PositionFor returns the Position value for the given file position p.
+// If p is out of bounds, it is adjusted to match the File.Offset behavior.
+// p must be a Pos value in file or NoPos. Calling token.PositionFor(file, p)
+// is equivalent to calling file.PositionFor(p, false).
+func PositionFor(file *File, p Pos) Position {
+	return file.PositionFor(p, false)
+}

--- a/token/position_test.go
+++ b/token/position_test.go
@@ -1,0 +1,35 @@
+package token_test
+
+import (
+	gotoken "go/token"
+	"math"
+	"testing/quick"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/unmango/go-make/token"
+)
+
+var _ = Describe("Position", func() {
+	Describe("PositionFor", func() {
+		var file *token.File
+
+		BeforeEach(func() {
+			file = gotoken.NewFileSet().AddFile("test", 1, math.MaxInt-2)
+		})
+
+		It("should be equivalent to calling file.PositionFor(p, false)", func() {
+			err := quick.Check(func(p int) bool {
+				pos := token.Pos(p)
+
+				expected := file.PositionFor(pos, false)
+				actual := token.PositionFor(file, pos)
+
+				return actual == expected
+			}, nil)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
Follow the `pos, tok, lit := scanner.Scan()` pattern from go/scanner
Pos should refer to the token's starting position