### PR TITLE
Preserve quotes in recipe text

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -181,6 +181,7 @@ func (p *Parser) parseExpression() ast.Expr {
 
 func (p *Parser) parseComment() *ast.Comment {
 	pos, lit := p.pos, p.lit
+	lit = strings.TrimPrefix(lit, " ")
 	p.next()
 
 	return &ast.Comment{
@@ -385,14 +386,31 @@ func (p *Parser) parseVar(name ast.Expr) ast.Obj {
 	}
 }
 
+func (p *Parser) recipeTokenText() string {
+	switch p.tok {
+	case token.TEXT:
+		return p.lit
+	case token.COMMENT:
+		return "#" + p.lit
+	default:
+		return p.tok.String()
+	}
+}
+
 func (p *Parser) parseRecipe() *ast.Recipe {
 	prefixPos := p.expect(p.recipePrefix)
 	b := &strings.Builder{}
+	nextPos := prefixPos + 1
 	for p.tok != token.NEWLINE && p.tok != token.EOF {
-		if p.pos > prefixPos+1 {
-			b.WriteRune(' ')
+		if gap := int(p.pos - nextPos); gap > 0 {
+			for range gap {
+				b.WriteByte(' ')
+			}
 		}
-		b.WriteString(p.lit)
+
+		text := p.recipeTokenText()
+		b.WriteString(text)
+		nextPos = p.pos + token.Pos(len(text))
 		p.next()
 	}
 	if p.tok == token.NEWLINE {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -401,8 +401,10 @@ func (p *Parser) recipeTokenText() string {
 
 func (p *Parser) parseRecipe() *ast.Recipe {
 	prefixPos := p.expect(p.recipePrefix)
+	prefixText := p.recipePrefix.String()
+	prefixWidth := token.Pos(len(prefixText))
 	b := &strings.Builder{}
-	nextPos := prefixPos + 1
+	nextPos := prefixPos + prefixWidth
 	for p.tok != token.NEWLINE && p.tok != token.EOF {
 		if gap := int(p.pos - nextPos); gap > 0 {
 			for range gap {
@@ -420,11 +422,11 @@ func (p *Parser) parseRecipe() *ast.Recipe {
 	}
 
 	return &ast.Recipe{
-		Prefix:    token.TAB,
+		Prefix:    p.recipePrefix,
 		PrefixPos: prefixPos,
 		Text: ast.Text{
 			Value:    b.String(),
-			ValuePos: prefixPos + 1,
+			ValuePos: prefixPos + prefixWidth,
 		},
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -181,6 +181,8 @@ func (p *Parser) parseExpression() ast.Expr {
 
 func (p *Parser) parseComment() *ast.Comment {
 	pos, lit := p.pos, p.lit
+	// The scanner keeps the post-# space so recipe lines can round-trip comments
+	// exactly; top-level comment nodes still normalize that leading space away.
 	lit = strings.TrimPrefix(lit, " ")
 	p.next()
 

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -389,6 +389,32 @@ var _ = Describe("Parser", func() {
 		}))
 	})
 
+	It("should preserve comments and operator tokens in a recipe", func() {
+		buf := bytes.NewBufferString("target:\n\t@echo $@: # keep this comment")
+		p := parser.New(buf, file)
+
+		f, err := p.ParseFile()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Contents).To(ConsistOf(&ast.Rule{
+			Colon: token.Pos(7),
+			Targets: []ast.Expr{&ast.Text{
+				Value:    "target",
+				ValuePos: token.Pos(1),
+			}},
+			PreReqs:      []ast.Expr{},
+			OrderPreReqs: []ast.Expr{},
+			Recipes: []*ast.Recipe{{
+				Prefix:    token.TAB,
+				PrefixPos: token.Pos(9),
+				Text: ast.Text{
+					Value:    "@echo $@: # keep this comment",
+					ValuePos: token.Pos(10),
+				},
+			}},
+		}))
+	})
+
 	It("should Parse a target with a prereq and a recipe", func() {
 		buf := bytes.NewBufferString("target: prereq\n\trecipe")
 		p := parser.New(buf, file)

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -363,6 +363,32 @@ var _ = Describe("Parser", func() {
 		}))
 	})
 
+	It("should preserve double quotes in a recipe", func() {
+		buf := bytes.NewBufferString("target:\n\t@echo \"testing has been started...\"")
+		p := parser.New(buf, file)
+
+		f, err := p.ParseFile()
+
+		Expect(err).NotTo(HaveOccurred())
+		Expect(f.Contents).To(ConsistOf(&ast.Rule{
+			Colon: token.Pos(7),
+			Targets: []ast.Expr{&ast.Text{
+				Value:    "target",
+				ValuePos: token.Pos(1),
+			}},
+			PreReqs:      []ast.Expr{},
+			OrderPreReqs: []ast.Expr{},
+			Recipes: []*ast.Recipe{{
+				Prefix:    token.TAB,
+				PrefixPos: token.Pos(9),
+				Text: ast.Text{
+					Value:    "@echo \"testing has been started...\"",
+					ValuePos: token.Pos(10),
+				},
+			}},
+		}))
+	})
+
 	It("should Parse a target with a prereq and a recipe", func() {
 		buf := bytes.NewBufferString("target: prereq\n\trecipe")
 		p := parser.New(buf, file)

--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -57,10 +57,6 @@ func (s *Scanner) skipWhitespace() {
 }
 
 func (s *Scanner) scanComment() string {
-	if bytes.ContainsRune(s.s.Bytes(), ' ') {
-		s.next() // skip space following '#'
-	}
-
 	b := strings.Builder{}
 	for !s.done && !bytes.ContainsRune(s.s.Bytes(), '\n') {
 		b.Write(s.s.Bytes())

--- a/scanner/scanner_test.go
+++ b/scanner/scanner_test.go
@@ -169,10 +169,10 @@ var _ = Describe("Scanner", func() {
 	DescribeTable("Scan comment tokens",
 		Entry(nil, "#", ""),
 		Entry(nil, "#some text", "some text"),
-		Entry(nil, "# some text", "some text"),
+		Entry(nil, "# some text", " some text"),
 		Entry(nil, "#\n", ""),
 		Entry(nil, "#some text\n", "some text"),
-		Entry(nil, "# some text\n", "some text"),
+		Entry(nil, "# some text\n", " some text"),
 		func(input, expected string) {
 			buf := bytes.NewBufferString(input)
 			s := scanner.New(buf, file)

--- a/testdata/roundtrip/recipe-comment-var-ref.mk
+++ b/testdata/roundtrip/recipe-comment-var-ref.mk
@@ -1,0 +1,2 @@
+target:
+	@echo $@: # keep this comment

--- a/testdata/roundtrip/recipe-double-quotes.mk
+++ b/testdata/roundtrip/recipe-double-quotes.mk
@@ -1,0 +1,2 @@
+target:
+	@echo "testing has been started..."


### PR DESCRIPTION
- **Ensures parser preserves double quotes in recipes**
- **Round trip test**
- **Initial AI pass**

Resolves #91
